### PR TITLE
Bump node-fetch to resolve security vulnerability

### DIFF
--- a/examples/gatsby-auth0-netlify-functions/package.json
+++ b/examples/gatsby-auth0-netlify-functions/package.json
@@ -14,7 +14,7 @@
     "@serverless-jwt/netlify": "0.1.8",
     "dotenv": "^8.2.0",
     "gatsby": "^2.23.12",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^2.6.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"
   },

--- a/examples/nextjs-auth0/package.json
+++ b/examples/nextjs-auth0/package.json
@@ -22,7 +22,7 @@
     "@auth0/auth0-react": "^1.0.0",
     "@serverless-jwt/next": "^0.1.8",
     "next": "9.4.4",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^2.6.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   }

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -32,6 +32,6 @@
   "dependencies": {
     "@serverless-jwt/jwt-verifier": "0.2.0",
     "@types/node-fetch": "^2.5.7",
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.1"
   }
 }

--- a/packages/jwt-verifier/package.json
+++ b/packages/jwt-verifier/package.json
@@ -41,7 +41,7 @@
     "jsonwebtoken": "^8.5.1",
     "limiter": "^1.1.5",
     "lru-memoizer": "^2.1.2",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^2.6.1",
     "wretch": "^1.7.2"
   }
 }


### PR DESCRIPTION
Snyk reports a security vulnerability in `node-fetch <2.6.1`: https://snyk.io/vuln/SNYK-JS-NODEFETCH-674311

As this affects the next-auth0 repository, I wanted to patch node-fetch in `@serverless-jwt/jwt-verifier`, while I was at it, I updated the other node-fetch usages as well.