### PR TITLE
fix: correct Next.js import path

### DIFF
--- a/examples/nextjs-auth0/components/Layout.js
+++ b/examples/nextjs-auth0/components/Layout.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Header from './header';
+import Header from './Header';
 
 export default function Layout({ children }) {
   return (


### PR DESCRIPTION
Import `Header.js` in the same directory - there is no `header.js`.