### PR TITLE
fix: update .env-template

### DIFF
--- a/examples/gatsby-auth0-netlify-functions/.env-template
+++ b/examples/gatsby-auth0-netlify-functions/.env-template
@@ -1,6 +1,6 @@
 JWT_ISSUER=https://you.auth0.com/
 JWT_AUDIENCE=urn:tv-shows
-GATSBY_AUTH0_DOMAIN=https://you.auth0.com/
+GATSBY_AUTH0_DOMAIN=you.auth0.com/
 GATSBY_AUTH0_CLIENT_ID=...
 GATSBY_AUTH0_AUDIENCE=urn:tv-shows
-GATSBY_AUTH0_SCOPE=openid profile read:shows
+GATSBY_AUTH0_SCOPE='openid profile read:shows'


### PR DESCRIPTION
Remove protocol otherwise the URL breaks on login as `https://http...`

Also added quotes on the last variable. Not needed for Gatsby for in general for .env files so it is valid as a shell file.