### PR TITLE
fix: next.js types

### DIFF
--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -8,10 +8,6 @@ export interface NextJwtVerifierOptions extends JwtVerifierOptions {
   handleError?(res: NextApiResponse, err: Error | JwtVerifierError): Promise<void>;
 }
 
-export interface IApiRoute {
-  (req: NextApiRequest, res: NextApiResponse): Promise<void>;
-}
-
 export interface IdentityContext {
   /**
    * The token that was provided.


### PR DESCRIPTION
The `IApiRoute` interface inside this module is not compatible with other wrappers for nextapis. I suggest changing to `NextApiHandler` instead to avoid conflicts like this:

![image](https://user-images.githubusercontent.com/178512/135680130-87a2a50b-68b8-4057-bdf5-784e46d1a65b.png)
